### PR TITLE
Fix cleanup bug

### DIFF
--- a/source/code/PlayFabSharedInternal/Include/XAsyncOperation.h
+++ b/source/code/PlayFabSharedInternal/Include/XAsyncOperation.h
@@ -122,7 +122,8 @@ Result<T> XAsyncOperation<T>::GetResult(XAsyncBlock* asyncBlock) noexcept
 template<typename T>
 void XAsyncOperation<T>::OnFailed(HRESULT hr) noexcept
 {
-    // Submit synchronous failures to TaskQueue so that completion runs on the correct port
+    // Submit synchronous failures to TaskQueue so that completion runs on the correct port.
+    // Overriding ITaskQueueWork::WorkCancelled to complete the AsyncOp even if the TaskQueue is terminated
     struct AsyncCompletion : public ITaskQueueWork
     {
         SharedPtr<AsyncOpContext<T>> asyncContext;

--- a/source/test/UnitTests/Support/Event.cpp
+++ b/source/test/UnitTests/Support/Event.cpp
@@ -24,7 +24,7 @@ void Event::Set() noexcept
     UNREFERENCED_PARAMETER(result);
 }
 
-bool Event::Wait(DWORD timeoutMs) noexcept
+bool Event::Wait(DWORD timeoutMs) const noexcept
 {
     DWORD result = WaitForSingleObject(m_handle, timeoutMs);
     return result == WAIT_OBJECT_0;

--- a/source/test/UnitTests/Support/Event.h
+++ b/source/test/UnitTests/Support/Event.h
@@ -18,7 +18,7 @@ public:
     Event& operator=(Event other) = delete;
 
     void Set() noexcept;
-    bool Wait(DWORD timeoutMs) noexcept;
+    bool Wait(DWORD timeoutMs = INFINITE) const noexcept;
 
 private:
     HANDLE m_handle{ nullptr };

--- a/source/test/UnitTests/Tests/RunContextTests.cpp
+++ b/source/test/UnitTests/Tests/RunContextTests.cpp
@@ -43,7 +43,7 @@ private:
 
     void OnCancellation() noexcept override
     {
-        m_rc.Terminate(nullptr, nullptr);
+        m_rc.TaskQueue().Terminate(nullptr, nullptr);
     }
 
     RunContext m_rc;


### PR DESCRIPTION
* Fixes a bug where the PFUnitializeAsync callback could be invoked prior to the RunContext::Terminate flow completing & releasing all allocated memory.  This was caught with the CustomMemHooks UnitTest, and was caused by the recent changes to the cleanup flow to accomodate tracing.  Note that the bug existed before then, it just reproduces much more easily after that change.  The ordering that leads to the bug goes something like this: 
  1.  RunContext::State::OnTerminated called with the last completed termination. List of ITerminationListeners copied into vector on the stack.
  2. That local vector of ITerminationListeners are invoked one at a time.  One of the listeners is GlobalState, and when that listener is invoked, the PFUnitializeAsync operation will be completed, returning to title. Title is free to cleanup memory manager at this point.
  3. RunContext::State::OnTerminated stack cleanup happens, releasing local (mem-hooked) vector, potentially AFTER title has cleaned up memory manager, causing crash.
* Now that RunContext::Terminate only allows a single termination, changes were made to support cancellation of other TaskQueue work without terminating a RunContext.  Because XTaskQueues don't support cancelling individual callbacks submitted to them, we have two options. Depending on the work being cancelled, one may make more sense than the other.
  1.  Let the TaskQueue callback run as scheduled, checking for cancellation in the callback and proceeding accordingly. If the callback is still pending during cleanup the queue will be terminated and the callback will not be called.
  2.  Terminate the TaskQueue, which cancels all callbacks submitted to it. In cases where the task queue is only used for a specific purpose, this option may be preferable. If unrelated work may also be submitted to the same TaskQueue (or a derived queue), terminating the queue would also force that work to be cancelled.
* Bolstering tests around RunContext::Terminate which is a critical part of the PFUninitializeAsync flow.  These tests reveal several other race conditions which will be tracked separately and addressed in future PRs.