### PR TITLE
Fix a couple of RunContext termination bugs

### DIFF
--- a/make.js
+++ b/make.js
@@ -161,7 +161,7 @@ function makeFeatureGroupFiles(featureGroup, sourceDir, apiOutputDir) {
         playFabCoreProjectFiles[relativePath + "\\" + filename] = relativePath;
     }
 
-    relativePath = "Source\\" + (featureGroup.name === "Shared" ? "Common" : featureGroup.name);
+    relativePath = "source\\" + (featureGroup.name === "Shared" ? "Common" : featureGroup.name);
     filename = partialFilename + "Types.h";
     var internalDataModelsHeader = getCompiledTemplate(path.resolve(sourceDir, "sdk_templates/Types.h.ejs"));
     writeFile(path.resolve(apiOutputDir, playFabCoreSourceDir + relativePath, filename), internalDataModelsHeader(locals));
@@ -176,7 +176,7 @@ function makeFeatureGroupFiles(featureGroup, sourceDir, apiOutputDir) {
     if (featureGroup.name !== "Shared") {
 
         // Internal APIs
-        relativePath = "Source\\" + featureGroup.name;
+        relativePath = "source\\" + featureGroup.name;
         filename = partialFilename + ".h";
         var internalApisHeader = getCompiledTemplate(path.resolve(sourceDir, "sdk_templates/Calls.h.ejs"));
         writeFile(path.resolve(apiOutputDir, playFabCoreSourceDir + relativePath, filename), internalApisHeader(locals));
@@ -195,7 +195,7 @@ function makeFeatureGroupFiles(featureGroup, sourceDir, apiOutputDir) {
             writeFile(path.resolve(apiOutputDir, playFabCoreSourceDir + relativePath, filename), publicApisHeader(locals));
             playFabCoreProjectFiles[relativePath + "\\" + filename] = relativePath;
 
-            relativePath = "Source\\Api";
+            relativePath = "source\\Api";
             filename = prefix + ".cpp";
             var publicApis = getCompiledTemplate(path.resolve(sourceDir, "sdk_templates/PFCalls.cpp.ejs"));
             writeFile(path.resolve(apiOutputDir, playFabCoreSourceDir + relativePath, filename), publicApis(locals));

--- a/sdk/build/GDK/PlayFabCore.GDK.vcxproj.filters.ejs
+++ b/sdk/build/GDK/PlayFabCore.GDK.vcxproj.filters.ejs
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Include" />
-    <Filter Include="Source" /><%
+    <Filter Include="include" />
+    <Filter Include="include\playfab" />
+    <Filter Include="source" /><%
 var filters = new Set();
 for(var file in projectFiles.PlayFabCore) {
     filters.add(projectFiles.PlayFabCore[file]);

--- a/sdk/build/Win32/PlayFabCore.UnitTests.vcxproj.ejs
+++ b/sdk/build/Win32/PlayFabCore.UnitTests.vcxproj.ejs
@@ -36,6 +36,7 @@ for (var file in projectFiles.PlayFabCore) {
     <ClCompile Include="..\..\source\Test\UnitTests\Mocks\HttpMock.cpp" />
     <ClCompile Include="..\..\source\Test\UnitTests\Support\AsyncTestContext.cpp" />
     <ClCompile Include="..\..\source\Test\UnitTests\Support\Event.cpp" />
+    <ClCompile Include="..\..\source\Test\UnitTests\Support\TaskQueue.cpp" />
     <ClCompile Include="..\..\source\Test\UnitTests\Tests\AsyncOpTests.cpp" />
     <ClCompile Include="..\..\source\Test\UnitTests\Tests\CancellationTokenTests.cpp" />
     <ClCompile Include="..\..\source\Test\UnitTests\Tests\GlobalStateTests.cpp" />
@@ -46,6 +47,7 @@ for (var file in projectFiles.PlayFabCore) {
     <ClInclude Include="..\..\source\Test\UnitTests\Mocks\MockResponses.h" />
     <ClInclude Include="..\..\source\Test\UnitTests\Support\AsyncTestContext.h" />
     <ClInclude Include="..\..\source\Test\UnitTests\Support\Event.h" />
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\TaskQueue.h" />
     <ClInclude Include="..\..\source\Test\UnitTests\Support\TestIncludes.h" />
     <ClInclude Include="..\..\source\Test\UnitTests\Support\TestMacros.h" />
     <ClInclude Include="..\..\source\Test\UnitTests\Support\TestSession.h" />

--- a/sdk/build/Win32/PlayFabCore.UnitTests.vcxproj.filters.ejs
+++ b/sdk/build/Win32/PlayFabCore.UnitTests.vcxproj.filters.ejs
@@ -33,67 +33,63 @@ for (var file in projectFiles.PlayFabCore) {
 } %>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\test\UnitTests\Support\AsyncTestContext.cpp">
+    <ClInclude Include="$(PlayFabCoreSourceDir)\source\stdafx.h" />
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\TestSession.h">
       <Filter>Source\Support</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Support\Event.cpp">
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\TestMacros.h">
       <Filter>Source\Support</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Mocks\HttpMock.cpp">
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\TestIncludes.h">
+      <Filter>Source\Support</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\AsyncTestContext.h">
+      <Filter>Source\Support</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\Event.h">
+      <Filter>Source\Support</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Mocks\MockResponses.h">
       <Filter>Source\Mocks</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Tests\TokenRefreshTests.cpp">
-      <Filter>Source\Tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Tests\TelemetryPipelineTests.cpp">
-      <Filter>Source\Tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Tests\AsyncOpTests.cpp">
-      <Filter>Source\Tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Tests\CancellationTokenTests.cpp">
-      <Filter>Source\Tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Tests\GlobalStateTests.cpp">
-      <Filter>Source\Tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\test\UnitTests\Tests\RunContextTests.cpp">
-      <Filter>Source\Tests</Filter>
-    </ClCompile>
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Mocks\HttpMock.h">
+      <Filter>Source\Mocks</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\Test\UnitTests\Support\TaskQueue.h">
+      <Filter>Source\Support</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\test\UnitTests\Support\AsyncTestContext.h">
+    <ClCompile Include="$(PlayFabCoreSourceDir)\source\stdafx.cpp" />
+    <ClCompile Include="..\..\source\Test\UnitTests\Support\AsyncTestContext.cpp">
       <Filter>Source\Support</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\UnitTests\Support\Event.h">
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Support\Event.cpp">
       <Filter>Source\Support</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\UnitTests\Support\TestMacros.h">
-      <Filter>Source\Support</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\UnitTests\Mocks\HttpMock.h">
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Tests\AsyncOpTests.cpp">
+      <Filter>Source\Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Tests\CancellationTokenTests.cpp">
+      <Filter>Source\Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Tests\GlobalStateTests.cpp">
+      <Filter>Source\Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Tests\TelemetryPipelineTests.cpp">
+      <Filter>Source\Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Tests\TokenRefreshTests.cpp">
+      <Filter>Source\Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Tests\RunContextTests.cpp">
+      <Filter>Source\Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Mocks\HttpMock.cpp">
       <Filter>Source\Mocks</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\Wrappers\PlayFabSession.h">
-      <Filter>Source\Wrappers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\Wrappers\ServiceConfig.h">
-      <Filter>Source\Wrappers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\Wrappers\TitlePlayer.h">
-      <Filter>Source\Wrappers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\Wrappers\TelemetryPipeline.h">
-      <Filter>Source\Wrappers</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\UnitTests\Mocks\MockResponses.h">
-      <Filter>Source\Mocks</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\UnitTests\Support\TestIncludes.h">
+    </ClCompile>
+    <ClCompile Include="..\..\source\Test\UnitTests\Support\TaskQueue.cpp">
       <Filter>Source\Support</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\test\UnitTests\Support\TestSession.h">
-      <Filter>Source\Support</Filter>
-    </ClInclude>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/sdk/build/Win32/PlayFabCore.Win32.vcxproj.filters.ejs
+++ b/sdk/build/Win32/PlayFabCore.Win32.vcxproj.filters.ejs
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Include" />
-    <Filter Include="Source" /><%
+    <Filter Include="include" />
+    <Filter Include="include\playfab" />
+    <Filter Include="source" /><%
 var filters = new Set();
 for(var file in projectFiles.PlayFabCore) {
     filters.add(projectFiles.PlayFabCore[file]);

--- a/sdk/source/PlayFabCore/source/Common/Entity.cpp
+++ b/sdk/source/PlayFabCore/source/Common/Entity.cpp
@@ -92,7 +92,7 @@ SharedPtr<TokenRefreshWorker> TokenRefreshWorker::MakeAndStart(SharedPtr<Entity>
     Allocator<TokenRefreshWorker> a;
     SharedPtr<TokenRefreshWorker> worker{ new (a.allocate(1)) TokenRefreshWorker{ entity, std::move(rc), std::move(tokenExpiredHandler) } };
 
-    worker->m_rc.TaskQueue().SubmitWork(worker);
+    worker->m_rc.TaskQueueSubmitWork(worker);
     return worker;
 }
 
@@ -109,7 +109,7 @@ void TokenRefreshWorker::Run()
 
         // TODO we will also need some logic to ensure this isn't overscheduled (ex. during suspend/resume when it is explicitly scheduled
         // without awaiting the normal interval)
-        m_rc.TaskQueue().SubmitWork(shared_from_this(), s_interval);
+        m_rc.TaskQueueSubmitWork(shared_from_this(), s_interval);
     }
 }
 
@@ -122,7 +122,7 @@ void TokenRefreshWorker::OnCancellation()
     //  2.  Terminate the TaskQueue, which cancels all callbacks submitted to it. This is fine in this case since nothing
     //      besides the TokenRefreshWorker will ever be submitted to this TaskQueue.
 
-    m_rc.TaskQueue().Terminate(nullptr, nullptr);
+    m_rc.TaskQueueTerminate();
 }
 
 void TokenRefreshWorker::GetToken(SharedPtr<Entity> entity) noexcept

--- a/sdk/source/PlayFabCore/source/Common/GlobalState.h
+++ b/sdk/source/PlayFabCore/source/Common/GlobalState.h
@@ -35,7 +35,7 @@ public:
 private:
     GlobalState(XTaskQueueHandle backgroundQueue) noexcept;
 
-    void OnTerminated(SharedPtr<ITerminationListener> self, void* context) noexcept override;
+    void OnTerminated(void* context) noexcept override;
     static HRESULT CALLBACK CleanupAsyncProvider(XAsyncOp op, XAsyncProviderData const* data);
 
     PlayFab::RunContext m_runContext;

--- a/sdk/source/PlayFabCore/source/Common/TokenExpiredHandler.cpp
+++ b/sdk/source/PlayFabCore/source/Common/TokenExpiredHandler.cpp
@@ -123,7 +123,7 @@ void TokenExpiredHandler::SharedState::Invoke(String&& entityId) const noexcept
     {
         auto handler = pair.second;
 
-        handler->RunContext().TaskQueue().SubmitWork([this, handler, entityId]()
+        handler->RunContext().TaskQueueSubmitWork([this, handler, entityId]()
         {
             std::unique_lock<std::recursive_mutex> lock{ m_mutex }; // lock to avoid races with unregistering the handler
 

--- a/sdk/source/PlayFabCore/source/Common/TraceState.cpp
+++ b/sdk/source/PlayFabCore/source/Common/TraceState.cpp
@@ -184,8 +184,7 @@ HRESULT CALLBACK TraceState::CleanupAsyncProvider(XAsyncOp op, XAsyncProviderDat
         }
 
         // Forcibily terminate any remaining work
-        RunContext& rc = context->traceState->m_runContext; // we are about to move traceState
-        rc.Terminate(std::move(context->traceState), context);
+        context->traceState->m_runContext.Terminate(*context->traceState, context);
         return E_PENDING;
     }
     default:
@@ -195,16 +194,12 @@ HRESULT CALLBACK TraceState::CleanupAsyncProvider(XAsyncOp op, XAsyncProviderDat
     }
 }
 
-void TraceState::OnTerminated(SharedPtr<ITerminationListener> traceState, void* c) noexcept
+void TraceState::OnTerminated(void* c) noexcept
 {
     UniquePtr<CleanupContext> context{ static_cast<CleanupContext*>(c) };
     XAsyncBlock* asyncBlock{ context->asyncBlock }; // Keep copy of asyncBlock pointer to complete after cleaning up context
 
-    // Cleanup TraceState
-    assert(!context->traceState);
-    traceState.reset(); 
-
-    // Cleanup context
+    // Cleanup context. TraceState will be destroyed here
     context.reset();
 
     // TraceState fully cleaned up!

--- a/sdk/source/PlayFabCore/source/Common/TraceState.h
+++ b/sdk/source/PlayFabCore/source/Common/TraceState.h
@@ -48,7 +48,7 @@ private:
     ) noexcept;
 
     // ITerminationListener
-    void OnTerminated(SharedPtr<ITerminationListener> traceState, void* context) noexcept override;
+    void OnTerminated(void* context) noexcept override;
 
     RunContext m_runContext;
     Vector<UniquePtr<TraceOutput>> const m_outputs;

--- a/sdk/source/PlayFabCore/source/Telemetry/TelemetryPipeline.cpp
+++ b/sdk/source/PlayFabCore/source/Telemetry/TelemetryPipeline.cpp
@@ -106,7 +106,7 @@ EventUploader::EventUploader(RunContext rc, SharedPtr<TitlePlayer> uploadingEnti
 void EventUploader::Start()
 {
     // Should never be called twice. Make clearer from interface
-    m_rc.TaskQueue().SubmitWork(shared_from_this(), 0);
+    m_rc.TaskQueueSubmitWork(shared_from_this(), 0);
 }
 
 void EventUploader::Run() noexcept
@@ -160,7 +160,7 @@ void EventUploader::Run() noexcept
     lock.unlock();
 
     // Using a polling model to check EventBuffer again after we've emptied it. This is the same algorithm used by XPlatCpp Event Pipeline.
-    m_rc.TaskQueue().SubmitWork(shared_from_this(), m_pollDelayInMs);
+    m_rc.TaskQueueSubmitWork(shared_from_this(), m_pollDelayInMs);
 }
 
 }

--- a/sdk/source/PlayFabSharedInternal/include/RunContext.h
+++ b/sdk/source/PlayFabSharedInternal/include/RunContext.h
@@ -28,8 +28,8 @@ struct ITaskQueueWork
 // RunContext is an execution context for asyncronous work in PlayFab. It provides an interface for basic XAsync primitives, as well
 // as a way to attach and track arbitrary asyncronous work associated with the RunContext.
 // 
-// During SDK cleanup, RunContext::Terminate will be called for all remaining RunContexts and all pending pending async work will be forcibly
-// ended. The RunContext will then awaiting its completion (including cleanup of any associated state), and then notify the Terminate caller 
+// During SDK cleanup, RunContext::Terminate will be called for all remaining RunContexts and all pending async work will be forcibly
+// ended. The RunContext will then await its completion (including cleanup of any associated state), and then notify the Terminate caller 
 // that everything it is safe to return the the client so they can continue their cleanup.
 class RunContext : public ITerminable
 {

--- a/sdk/source/PlayFabSharedInternal/include/RunContext.h
+++ b/sdk/source/PlayFabSharedInternal/include/RunContext.h
@@ -1,5 +1,3 @@
-// Run context is the context needed to perform and XAsync operation
-
 #pragma once
 
 #include "XTaskQueue.h"
@@ -8,80 +6,43 @@
 namespace PlayFab
 {
 
+// Interfaces used with RunContext
 struct ITerminationListener
 {
     virtual ~ITerminationListener() = default;
-
-    // When Terminating, ownership of the termination listener should be transferred back to the termination lister
-    // as part of invoking the OnTerminated callback. This allows listener object to be destroyed within the OnTerminated callback.
-    virtual void OnTerminated(_In_ SharedPtr<ITerminationListener> self, void* context) = 0;
+    virtual void OnTerminated(void* context) = 0;
 };
 
 struct ITerminable
 {
     virtual ~ITerminable() = default;
-    virtual void Terminate(_In_opt_ SharedPtr<ITerminationListener> listener, void* context) = 0;
+    virtual void Terminate(ITerminationListener& listener, void* context) = 0;
 };
 
-// Interface for work submitted to TaskQueues
 struct ITaskQueueWork
 {
     virtual void Run() = 0;
     virtual void WorkCancelled() {}
 };
 
-// Wrapper to enable submitting arbitrary lambdas to TaskQueues
-template<typename TCallback>
-class TaskQueueWork : public ITaskQueueWork
-{
-public:
-    TaskQueueWork(TCallback&& callback);
-
-    // ITaskQueueWork
-    void Run() override;
-
-private:
-    TCallback m_callback;
-};
-
-// RAII wrapper around XTaskQueueHandle
-class TaskQueue : public ITerminable
-{
-public:
-    TaskQueue DeriveWorkQueue() const noexcept;
-    static TaskQueue DeriveWorkQueue(XTaskQueueHandle handle) noexcept;
-
-    TaskQueue(const TaskQueue& other) noexcept = default;
-    TaskQueue(TaskQueue&& other) noexcept = default;
-    TaskQueue& operator=(TaskQueue const& other) noexcept = delete;
-    TaskQueue& operator=(TaskQueue&& other) noexcept = delete;
-    ~TaskQueue() noexcept = default;
-
-    XTaskQueueHandle Handle() const noexcept;
-    
-    void SubmitWork(SharedPtr<ITaskQueueWork> work, uint32_t delayInMs = 0) const noexcept;
-    template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>* = 0>
-    void SubmitWork(TCallback work, uint32_t delayInMs = 0) const noexcept;
-
-    void SubmitCompletion(SharedPtr<ITaskQueueWork> completion) const noexcept;
-    template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>* = 0>
-    void SubmitCompletion(TCallback completion) const noexcept;
-
-    void Terminate(_In_opt_ SharedPtr<ITerminationListener> listener, void* context) override;
-
-private:
-    class State;
-
-    TaskQueue(SharedPtr<State> state) noexcept;
-
-    SharedPtr<State> m_state;
-};
-
+// RunContext is an execution context for asyncronous work in PlayFab. It provides an interface for basic XAsync primitives, as well
+// as a way to attach and track arbitrary asyncronous work associated with the RunContext.
+// 
+// During SDK cleanup, RunContext::Terminate will be called for all remaining RunContexts and all pending pending async work will be forcibly
+// ended. The RunContext will then awaiting its completion (including cleanup of any associated state), and then notify the Terminate caller 
+// that everything it is safe to return the the client so they can continue their cleanup.
 class RunContext : public ITerminable
 {
 public:
-    static RunContext Root(XTaskQueueHandle backgroundQueue) noexcept;
+    // Creates a Root RunContext. Should only done by global state
+    static RunContext Root(XTaskQueueHandle queue) noexcept;
+
+    // Derive a new RunContext from another. Subtasks that can be cancelled, succeed, or fail independently should derive their own RunContext
+    // from their parent's RunContext. The derived RunContext will use a derived TaskQueue as well.
     RunContext Derive() noexcept;
+
+    // Derive a new RunContext from another, but use an independent TaskQueue rather than a derived one. This is typically used when a client has
+    // specifed a specific queue for a given piece of work (ex. a public XAsync API call or a client callback that was registered with a queue)
     RunContext DeriveOnQueue(XTaskQueueHandle queueHandle) noexcept;
 
     RunContext(RunContext const&) noexcept = default;
@@ -90,47 +51,90 @@ public:
     RunContext& operator=(RunContext&&) noexcept = delete;
     ~RunContext() noexcept = default;
 
-    PlayFab::TaskQueue TaskQueue() const noexcept;
+public: // XTaskQueue shims
+    // Retreive an XTaskQueueHandle to be passed to XAsyncAsync APIs
+    XTaskQueueHandle TaskQueueHandle() const noexcept;
+
+    // Submits an ITaskQueueWork object to the TaskQueue work port
+    void TaskQueueSubmitWork(SharedPtr<ITaskQueueWork> work, uint32_t delayInMs = 0) const noexcept;
+
+    // Submits an arbitrary lambda to the TaskQueue work port
+    template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>* = 0>
+    void TaskQueueSubmitWork(TCallback work, uint32_t delayInMs = 0) const noexcept;
+
+    // Submits an ITaskQueueWork object to the TaskQueue completion port
+    void TaskQueueSubmitCompletion(SharedPtr<ITaskQueueWork> completion) const noexcept;
+
+    // Submits an arbitrary lambda to the TaskQueue completion port
+    template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>* = 0>
+    void TaskQueueSubmitCompletion(TCallback completion) const noexcept;
+
+    // Terminates the XTaskQueue. Can be used to cancel all work submitted to the TaskQueue. Note however that this will also cancel work submitted
+    // to derived RunContext's TaskQueue
+    void TaskQueueTerminate() noexcept;
+
+public:
+    // CancellationToken that can be used to cancel associated work and/or be notified when a cancellation request has been made
     PlayFab::CancellationToken CancellationToken() const noexcept;
 
-    // RunContext::Terminate should be called exactly once during PFCleanup. Allowing multiple terminations if a single
-    // RunContext prevents the RunContext from guaranteeing that it has completely cleaning up its state prior to each
-    // TerminationListener being notified of termination.
-    void Terminate(_In_ SharedPtr<ITerminationListener> listener, _In_opt_ void* context) noexcept override;
+    // Registers an arbitrary piece of work with the RunContext. During Termination, if the work has not yet been unregistered,
+    // the RunContext will alert the registered terminable that the client has requested cleanup and all work should be terminated
+    // as soon as possible.
+    bool RegisterTerminableAndCheck(ITerminable& terminable) noexcept;
+
+    // Unregisters a previously registered terminable. Typically done when the work has completed and has cleaned up any associated state.
+    bool UnregisterTerminableAndCheck(ITerminable& terminable) noexcept;
+
+    // Terminates the TaskQueue, any terminatbles registered with RegisterTerminableAndCheck, and any Derived RunContexts. The provided
+    // ITerminationListener will be notified upon completion.
+    // 
+    // Terminate should only called during PFCleanup. Allowing multiple terminations if a single RunContext prevents the RunContext from
+    // guaranteeing that it has completely cleaning up its state prior to each listener being notified. 
+    void Terminate(ITerminationListener& listener, void* context) noexcept override;
 
 private:
-    class State;
+    RunContext(SharedPtr<class RunContextState> state) noexcept;
 
-    RunContext(SharedPtr<State> state) noexcept;
-
-    SharedPtr<State> m_state;
+    SharedPtr<class RunContextState> m_state;
 };
 
 //------------------------------------------------------------------------------
 // Template implementations
 //------------------------------------------------------------------------------
-template<typename TCallback>
-TaskQueueWork<TCallback>::TaskQueueWork(TCallback&& callback) : m_callback{ std::move(callback) }
-{
-}
 
-// ITaskQueueWork
-template<typename TCallback>
-void TaskQueueWork<TCallback>::Run()
+namespace Detail
 {
-    m_callback();
+
+// Wrapper to enable submitting arbitrary lambdas to TaskQueues
+template<typename TCallback>
+class TaskQueueWork : public ITaskQueueWork
+{
+public:
+    TaskQueueWork(TCallback&& callback) : m_callback{ std::move(callback) } 
+    {
+    }
+    
+private:
+    void Run() override
+    {
+        m_callback();
+    }
+
+    TCallback m_callback;
+};
+
+} // namespace Detail
+
+template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>*>
+void RunContext::TaskQueueSubmitWork(TCallback work, uint32_t delayInMs) const noexcept
+{
+    TaskQueueSubmitWork(MakeShared<Detail::TaskQueueWork<TCallback>>(std::move(work)), delayInMs);
 }
 
 template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>*>
-void TaskQueue::SubmitWork(TCallback work, uint32_t delayInMs) const noexcept
+void RunContext::TaskQueueSubmitCompletion(TCallback completion) const noexcept
 {
-    SubmitWork(MakeShared<TaskQueueWork<TCallback>>(std::move(work)), delayInMs);
-}
-
-template<typename TCallback, typename std::enable_if_t<!std::is_assignable_v<SharedPtr<ITaskQueueWork>, TCallback>>*>
-void TaskQueue::SubmitCompletion(TCallback completion) const noexcept
-{
-    SubmitCompletion(MakeShared<TaskQueueWork<TCallback>>(std::move(completion)));
+    TaskQueueSubmitCompletion(MakeShared<Detail::TaskQueueWork<TCallback>>(std::move(completion)));
 }
 
 }

--- a/sdk/source/PlayFabSharedInternal/include/XAsyncOperation.h
+++ b/sdk/source/PlayFabSharedInternal/include/XAsyncOperation.h
@@ -143,7 +143,7 @@ void XAsyncOperation<T>::OnFailed(HRESULT hr) noexcept
     completion->asyncContext = m_asyncContext;
     completion->hr = hr;
 
-    RunContext().TaskQueue().SubmitCompletion(completion);
+    RunContext().TaskQueueSubmitCompletion(completion);
 }
 
 template<typename T>

--- a/sdk/source/PlayFabSharedInternal/include/XAsyncProviderBase.h
+++ b/sdk/source/PlayFabSharedInternal/include/XAsyncProviderBase.h
@@ -15,12 +15,12 @@ namespace PlayFab
 // 
 // Each XAsync API should use a derived provider class and override the relevant operations: Begin, DoWork,
 // and GetResult.
-class XAsyncProviderBase
+class XAsyncProviderBase : public ITerminable
 {
 public:
     XAsyncProviderBase(const XAsyncProviderBase&) = delete;
     XAsyncProviderBase& operator=(const XAsyncProviderBase&) = delete;
-    virtual ~XAsyncProviderBase() noexcept = default;
+    virtual ~XAsyncProviderBase() noexcept;
 
     // Runs an XAsync Provider. After calling Run, the provider operations Begin, DoWork, and GetResult will 
     // be called by the XAsync framework. The lifetime of the provider will be managed by the Provider
@@ -76,9 +76,16 @@ protected:
     const char* const identityName;
 
 private:
+    // ITerminable
+    void Terminate(ITerminationListener& listener, void* context) noexcept override;
+
     static HRESULT CALLBACK XAsyncProvider(_In_ XAsyncOp op, _Inout_ const XAsyncProviderData* data) noexcept;
+
     RunContext m_runContext;
     XAsyncBlock* m_async{ nullptr };
+
+    ITerminationListener* m_terminationListener{ nullptr };
+    void* m_terminationListenerContext{ nullptr };
 };
 
 } // namespace PlayFab

--- a/sdk/source/PlayFabSharedInternal/source/RunContext.cpp
+++ b/sdk/source/PlayFabSharedInternal/source/RunContext.cpp
@@ -6,67 +6,129 @@ namespace PlayFab
 
 static uint32_t g_nextId{ 0 };
 
+// RAII wrapper of XTaskQueueHandle
+class TaskQueue
+{
+public:
+    // The only queues we should use internally should be derived from another Queue. We don't want to directly
+    // submit work to a client owned queue because we will terminate queues during cleanup.
+    TaskQueue DeriveWorkQueue() const noexcept;
+    static TaskQueue DeriveWorkQueue(XTaskQueueHandle handle) noexcept;
+
+    TaskQueue(XTaskQueueHandle handle) noexcept; // Takes ownership of handle
+    TaskQueue(const TaskQueue& other) noexcept = delete;
+    TaskQueue(TaskQueue&& other) noexcept;
+    TaskQueue& operator=(TaskQueue const& other) noexcept = delete;
+    TaskQueue& operator=(TaskQueue&& other) noexcept = delete;
+    ~TaskQueue() noexcept;
+
+    XTaskQueueHandle Handle() const noexcept;
+
+private:
+    XTaskQueueHandle m_handle{ nullptr };
+};
+
+class RunContextState : public ITerminable, public ITerminationListener, public std::enable_shared_from_this<RunContextState>
+{
+public:
+    static SharedPtr<RunContextState> Root(XTaskQueueHandle queueHandle) noexcept;
+    SharedPtr<RunContextState> Derive() noexcept;
+    SharedPtr<RunContextState> DeriveOnQueue(XTaskQueueHandle queueHandle) noexcept;
+
+    RunContextState(TaskQueue&& queue, PlayFab::CancellationToken&& ct, SharedPtr<RunContextState> parent) noexcept;
+    RunContextState(RunContextState const&) noexcept = delete;
+    RunContextState(RunContextState&&) noexcept = delete;
+    RunContextState& operator=(RunContextState const&) noexcept = delete;
+    RunContextState& operator=(RunContextState&&) noexcept = delete;
+    ~RunContextState() noexcept;
+
+public:
+    XTaskQueueHandle TaskQueueHandle() const noexcept;
+    void TaskQueueSubmitCallback(XTaskQueuePort port, SharedPtr<ITaskQueueWork> work, uint32_t delayInMs) noexcept;
+    void TaskQueueTerminate() noexcept;
+
+    PlayFab::CancellationToken CancellationToken() const noexcept;
+
+    bool RegisterTerminableAndCheck(ITerminable& terminable) noexcept;
+    bool UnregisterTerminableAndCheck(ITerminable& terminable) noexcept;
+
+    void Terminate(ITerminationListener& listener, void* context) override;
+
+private:
+    // ITerminationListener
+    void OnTerminated(void* context) noexcept override; 
+
+    // XTaskQueue callbacks
+    static void CALLBACK TaskQueueCallback(void* context, bool cancelled) noexcept;
+    static void CALLBACK TaskQueueTerminated(void* context) noexcept;
+
+    static void CheckTerminationAndNotifyListener(SharedPtr<RunContextState> runContext, std::unique_lock<std::mutex> lock) noexcept;
+
+    std::mutex m_mutex;
+    std::recursive_mutex m_terminationMutex;
+    TaskQueue const m_queue;
+    PlayFab::CancellationToken m_cancellationToken;
+    SharedPtr<RunContextState> m_parent;
+    Vector<WeakPtr<RunContextState>> m_children;
+    Vector<ITerminable*> m_terminables; // non-owning
+    size_t m_pendingTaskQueueCallbacks{ 0 };
+    bool m_terminated{ false };
+    ITerminationListener* m_terminationListener; // non-owning
+    void* m_terminationListenerContext;
+    size_t m_pendingTerminations{ 0 };
+    bool m_queueTerminated{ false };
+
+    // For debugging purposes only
+    uint32_t m_id;
+    uint32_t m_depth;
+};
+
 //------------------------------------------------------------------------------
 // TaskQueue
 //------------------------------------------------------------------------------
 
-class TaskQueue::State : public ITerminable
-{
-public:
-    // The only queues we should use internally should be derived from another Queue. We don't want to directly
-    // submit work to a client owned queue because we want to be able to terminate queues during cleanup.
-    SharedPtr<State> DeriveWorkQueue() const noexcept;
-    static SharedPtr<State> DeriveWorkQueue(XTaskQueueHandle handle) noexcept;
-
-    State(XTaskQueueHandle handle) noexcept;
-    State(State const&) = delete;
-    State(State&&) = delete;
-    State& operator=(State const&) = delete;
-    State& operator=(State&&) = delete;
-    ~State();
-
-    XTaskQueueHandle Handle() const noexcept;
-    void SubmitCallback(XTaskQueuePort port, SharedPtr<ITaskQueueWork> work, uint32_t delayInMs) const noexcept;
-    void Terminate(_In_opt_ SharedPtr<ITerminationListener> listener, void* context) override;
-
-private:
-    static void CALLBACK TaskQueueCallback(void* context, bool cancelled) noexcept;
-    static void CALLBACK TaskQueueTerminated(void* context) noexcept;
-
-    XTaskQueueHandle const m_handle{ nullptr };
-};
-
-TaskQueue::State::State(XTaskQueueHandle handle) noexcept :
+TaskQueue::TaskQueue(XTaskQueueHandle handle) noexcept :
     m_handle{ handle }
 {
     assert(handle);
 }
 
-TaskQueue::State::~State()
+TaskQueue::TaskQueue(TaskQueue&& other) noexcept :
+    m_handle{ other.m_handle }
 {
-    XTaskQueueCloseHandle(m_handle);
+    other.m_handle = nullptr;
 }
 
-SharedPtr<TaskQueue::State> TaskQueue::State::DeriveWorkQueue() const noexcept
+
+TaskQueue::~TaskQueue()
+{
+    if (m_handle)
+    {
+        XTaskQueueCloseHandle(m_handle);
+    }
+}
+
+TaskQueue TaskQueue::DeriveWorkQueue() const noexcept
 {
     return DeriveWorkQueue(m_handle);
 }
 
-SharedPtr<TaskQueue::State> TaskQueue::State::DeriveWorkQueue(XTaskQueueHandle handle) noexcept
+TaskQueue TaskQueue::DeriveWorkQueue(XTaskQueueHandle handle) noexcept
 {
-    SharedPtr<State> processQueue{ nullptr };
+    StdExtra::optional<TaskQueue> processQueue{}; // We will derive from process queue if handle is null
     if (!handle)
     {
         bool haveProcessQueue = XTaskQueueGetCurrentProcessTaskQueue(&handle);
         if (haveProcessQueue)
         {
             // Wrap process queue handle so that it gets closed
-            processQueue = MakeShared<State>(handle);
+            processQueue.emplace(handle);
         }
         else
         {
+            // Fatal situation
             TRACE_ERROR("Client provided null XTaskQueueHandle and no default process queue is available");
-            assert(false); // handle this
+            assert(false);
         }
     }
 
@@ -86,188 +148,19 @@ SharedPtr<TaskQueue::State> TaskQueue::State::DeriveWorkQueue(XTaskQueueHandle h
         assert(false);
     }
 
-    return MakeShared<State>(derivedHandle);
-}
-
-XTaskQueueHandle TaskQueue::State::Handle() const noexcept
-{
-    return m_handle;
-}
-
-using TaskQueueCallbackContext = SharedPtr<ITaskQueueWork>;
-
-void CALLBACK TaskQueue::State::TaskQueueCallback(void* context, bool cancelled) noexcept
-{
-    assert(context);
-
-    UniquePtr<TaskQueueCallbackContext> callbackContext{ static_cast<TaskQueueCallbackContext*>(context) };
-    if (cancelled)
-    {
-        (*callbackContext)->WorkCancelled();
-    }
-    else
-    {
-        (*callbackContext)->Run();
-    }
-}
-
-void TaskQueue::State::SubmitCallback(XTaskQueuePort port, SharedPtr<ITaskQueueWork> work, uint32_t delayInMs) const noexcept
-{
-    assert(work);
-    assert(m_handle);
-
-    UniquePtr<TaskQueueCallbackContext> context = MakeUnique<TaskQueueCallbackContext>(std::move(work));
-
-    HRESULT hr = XTaskQueueSubmitDelayedCallback(m_handle, port, delayInMs, context.get(), TaskQueueCallback);
-    if (SUCCEEDED(hr))
-    {
-        // Will be reclaimed in TaskQueueCallback
-        context.release();
-    }
-    else if (hr == E_ABORT)
-    {
-        // Queue was already terminated
-        (*context)->WorkCancelled();
-    }
-    else
-    {
-        // Other errors are likely fatal
-        TRACE_ERROR_HR(hr, "TaskQueue::SubmitCallback failed unexpectedly");
-        assert(false);
-    }
-}
-
-struct XTaskQueueTerminateContext
-{
-    SharedPtr<ITerminationListener> listener;
-    void* listenerContext;
-    XTaskQueueHandle handle; // for logging purposes only, not guaranteed to be valid in terminate callback
-};
-
-void CALLBACK TaskQueue::State::TaskQueueTerminated(void* ctx) noexcept
-{
-    UniquePtr<XTaskQueueTerminateContext> context{ static_cast<XTaskQueueTerminateContext*>(ctx) };
-
-    TRACE_VERBOSE("TaskQueue[id=%p] terminated", context->handle);
-
-    // Move listener & listenerContext onto the stack so we can free context before invoking termination listener callback
-    SharedPtr<ITerminationListener> listener{ std::move(context->listener) };
-    void* listenerContext{ context->listenerContext };
-    context.reset();
-
-    if (listener)
-    {
-        ITerminationListener& ref{ *listener }; // we are about to move context->listener
-        ref.OnTerminated(std::move(listener), listenerContext);
-    }
-}
-
-void TaskQueue::State::Terminate(_In_opt_ SharedPtr<ITerminationListener> listener, void* listenerContext)
-{
-    TRACE_VERBOSE("TaskQueue[id=%p] terminating", m_handle);
-
-    assert(m_handle);
-
-    Allocator<XTaskQueueTerminateContext> a;
-    UniquePtr<XTaskQueueTerminateContext> context{ new (a.allocate(1)) XTaskQueueTerminateContext{ std::move(listener), listenerContext, m_handle} };
-
-    HRESULT hr = XTaskQueueTerminate(m_handle, false, context.get(), TaskQueueTerminated);
-    if (FAILED(hr))
-    {
-        // This likely indicates a bug, but consider the queue terminated to not block cleanup
-        assert(SUCCEEDED(hr));
-        TRACE_ERROR_HR(hr, "Failed to terminate queue");
-
-        if (listener)
-        {
-            ITerminationListener& listenerRef{ *listener }; // we are about to move listener
-            listenerRef.OnTerminated(std::move(listener), listenerContext);
-        }
-    }
-    else
-    {
-        context.release();
-    }
-}
-
-TaskQueue::TaskQueue(SharedPtr<State> state) noexcept :
-    m_state{ std::move(state) }
-{
-}
-
-TaskQueue TaskQueue::DeriveWorkQueue() const noexcept
-{
-    return TaskQueue{ m_state->DeriveWorkQueue() };
-}
-
-TaskQueue TaskQueue::DeriveWorkQueue(XTaskQueueHandle queueHandle) noexcept
-{
-    return TaskQueue{ State::DeriveWorkQueue(queueHandle) };
+    return TaskQueue{ derivedHandle };
 }
 
 XTaskQueueHandle TaskQueue::Handle() const noexcept
 {
-    return m_state->Handle();
-}
-
-void TaskQueue::SubmitWork(SharedPtr<ITaskQueueWork> work, uint32_t delayInMs) const noexcept
-{
-    return m_state->SubmitCallback(XTaskQueuePort::Work, std::move(work), delayInMs);
-}
-
-void TaskQueue::SubmitCompletion(SharedPtr<ITaskQueueWork> completion) const noexcept
-{
-    return m_state->SubmitCallback(XTaskQueuePort::Completion, std::move(completion), 0);
-}
-
-void TaskQueue::Terminate(SharedPtr<ITerminationListener> listener, void* context)
-{
-    return m_state->Terminate(std::move(listener), context);
+    return m_handle;
 }
 
 //------------------------------------------------------------------------------
-// RunContext
+// RunContextState
 //------------------------------------------------------------------------------
 
-class RunContext::State : public ITerminable, public ITerminationListener, public std::enable_shared_from_this<State>
-{
-public:
-    static SharedPtr<State> Root(XTaskQueueHandle queueHandle) noexcept;
-
-    SharedPtr<State> Derive() noexcept;
-    SharedPtr<State> DeriveOnQueue(XTaskQueueHandle queueHandle) noexcept;
-
-    State(PlayFab::TaskQueue&& q, PlayFab::CancellationToken&& ct, SharedPtr<State> parent) noexcept;
-    State(State const&) noexcept = delete;
-    State(State&&) noexcept = delete;
-    State& operator=(State const&) noexcept = delete;
-    State& operator=(State&&) noexcept = delete;
-    ~State() noexcept;
-
-    PlayFab::TaskQueue TaskQueue() const noexcept;
-    PlayFab::CancellationToken CancellationToken() const noexcept;
-
-    void Terminate(_In_ SharedPtr<ITerminationListener> listener, _In_opt_ void* context) override;
-
-private:
-    void OnTerminated(SharedPtr<ITerminationListener> self, void* context) override;
-
-    PlayFab::TaskQueue m_queue;
-    PlayFab::CancellationToken m_cancellationToken;
-
-    std::mutex m_mutex;
-    Vector<WeakPtr<ITerminable>> m_terminables;
-    size_t m_pendingTerminations{ 0 };
-    SharedPtr<ITerminationListener> m_terminationListener;
-    void* m_terminationListenerContext;
-    SharedPtr<State> m_parent;
-
-    // For debugging purposes only
-    uint32_t m_id;
-    uint32_t m_depth;
-};
-
-RunContext::State::State(PlayFab::TaskQueue&& q, PlayFab::CancellationToken&& ct, SharedPtr<State> parent) noexcept :
+RunContextState::RunContextState(TaskQueue&& q, PlayFab::CancellationToken&& ct, SharedPtr<RunContextState> parent) noexcept :
     m_queue{ std::move(q) },
     m_cancellationToken{ std::move(ct) },
     m_parent{ std::move(parent) },
@@ -276,114 +169,304 @@ RunContext::State::State(PlayFab::TaskQueue&& q, PlayFab::CancellationToken&& ct
 {
 }
 
-RunContext::State::~State()
+RunContextState::~RunContextState()
 {
+    TRACE_VERBOSE("RunContextState[id=%u]::~RunContextState", m_id);
 }
 
-SharedPtr<RunContext::State> RunContext::State::Root(XTaskQueueHandle queueHandle) noexcept
+SharedPtr<RunContextState> RunContextState::Root(XTaskQueueHandle queueHandle) noexcept
 {
-    return MakeShared<State>(TaskQueue::DeriveWorkQueue(queueHandle), CancellationToken::Root(), nullptr);
+    return MakeShared<RunContextState>(TaskQueue::DeriveWorkQueue(queueHandle), CancellationToken::Root(), nullptr);
 }
 
-SharedPtr<RunContext::State> RunContext::State::Derive() noexcept
+SharedPtr<RunContextState> RunContextState::Derive() noexcept
 {
-    SharedPtr<State> derived = MakeShared<State>(m_queue.DeriveWorkQueue(), m_cancellationToken.Derive(), shared_from_this());
+    SharedPtr<RunContextState> derived = MakeShared<RunContextState>(m_queue.DeriveWorkQueue(), m_cancellationToken.Derive(), shared_from_this());
 
     std::unique_lock<std::mutex> lock{ m_mutex };
-    m_terminables.push_back(derived);
+    m_children.push_back(derived);
 
     return derived;
 }
 
-SharedPtr<RunContext::State> RunContext::State::DeriveOnQueue(XTaskQueueHandle queueHandle) noexcept
+SharedPtr<RunContextState> RunContextState::DeriveOnQueue(XTaskQueueHandle queueHandle) noexcept
 {
-    SharedPtr<State> derived = MakeShared<State>(TaskQueue::DeriveWorkQueue(queueHandle), m_cancellationToken.Derive(), shared_from_this());
+    SharedPtr<RunContextState> derived = MakeShared<RunContextState>(TaskQueue::DeriveWorkQueue(queueHandle), m_cancellationToken.Derive(), shared_from_this());
 
     std::unique_lock<std::mutex> lock{ m_mutex };
-    m_terminables.push_back(derived);
+    m_children.push_back(derived);
 
     return derived;
 }
 
-PlayFab::TaskQueue RunContext::State::TaskQueue() const noexcept
+XTaskQueueHandle RunContextState::TaskQueueHandle() const noexcept
 {
-    return m_queue;
+    return m_queue.Handle();
 }
 
-PlayFab::CancellationToken RunContext::State::CancellationToken() const noexcept
+struct XTaskQueueCallbackContext
+{
+    SharedPtr<RunContextState> runContext;
+    SharedPtr<ITaskQueueWork> work;
+};
+
+void RunContextState::TaskQueueSubmitCallback(XTaskQueuePort port, SharedPtr<ITaskQueueWork> work, uint32_t delayInMs) noexcept
+{
+    assert(work);
+    assert(m_queue.Handle());
+
+    Allocator<XTaskQueueCallbackContext> a;
+    XTaskQueueCallbackContext* context = new (a.allocate(1)) XTaskQueueCallbackContext{ shared_from_this(), std::move(work) }; // reclaimed in TaskQueueCallback
+
+    std::unique_lock<std::mutex> lock{ m_mutex };
+    ++m_pendingTaskQueueCallbacks;
+    lock.unlock();
+
+    HRESULT hr = XTaskQueueSubmitDelayedCallback(m_queue.Handle(), port, delayInMs, context, TaskQueueCallback);
+    if (FAILED(hr))
+    {
+        // Treat other errors as cancellations by calling TaskQueueCallback so that the cancellation handler is called and
+        // m_pendingTaskQueueCallbacks is updated correctly
+        TaskQueueCallback(context, true);
+
+        TRACE_WARNING_HR(hr, "XTaskQueueSubmitDelayedCallback failed");
+        assert(hr == E_ABORT); // The only error we expect to ever see here is E_ABORT
+    }
+}
+
+void CALLBACK RunContextState::TaskQueueCallback(void* c, bool cancelled) noexcept
+{
+    assert(c);
+    UniquePtr<XTaskQueueCallbackContext> callbackContext{ static_cast<XTaskQueueCallbackContext*>(c) };
+    assert(callbackContext->runContext && callbackContext->work);
+
+    if (cancelled)
+    {
+        callbackContext->work->WorkCancelled();
+    }
+    else
+    {
+        callbackContext->work->Run();
+    }
+
+    SharedPtr<RunContextState> runContext{ std::move(callbackContext->runContext) };
+    callbackContext.reset();
+    
+    std::unique_lock<std::mutex> lock{ runContext->m_mutex };
+    --runContext->m_pendingTaskQueueCallbacks;
+
+    TRACE_VERBOSE("RunContextState[id=%u] TaskQueueCallback complete, %u remaining", runContext->m_id, runContext->m_pendingTaskQueueCallbacks);
+
+    CheckTerminationAndNotifyListener(std::move(runContext), std::move(lock));
+}
+
+void RunContextState::TaskQueueTerminate() noexcept
+{
+    std::unique_lock<std::mutex> lock{ m_mutex };
+
+    if (m_queueTerminated)
+    {
+        // Early out if the queue has already been terminated. Check needed because unlike XTaskQueueSubmitDelayedCallback, 
+        // XTaskQueueTerminate will succeed even after the queue has been terminated (creating another asyncronous callback that could
+        // run beyond RunContext::Terminate completing in some cases)
+        return;
+    }
+
+    // Track termination callbacks together with work callbacks. Because XTaskQueueTerminate doesn't guarantee that all submitted work callbacks 
+    // have completed before invoking termination callbacks (it only guarantees that they've been started), we need additional tracking to ensure
+    // all work has completed during RunContext termination
+    ++m_pendingTaskQueueCallbacks;
+    m_queueTerminated = true;
+    lock.unlock();
+
+    TRACE_VERBOSE("RunContextState[id=%u] TaskQueue terminating", m_id);
+
+    assert(m_queue.Handle());
+    Allocator<XTaskQueueCallbackContext> a;
+    XTaskQueueCallbackContext* context = new (a.allocate(1)) XTaskQueueCallbackContext{ shared_from_this() }; // reclaimed in TaskQueueTerminated
+
+    HRESULT hr = XTaskQueueTerminate(m_queue.Handle(), false, context, TaskQueueTerminated);
+    if (FAILED(hr))
+    {
+        // This likely indicates a bug, but consider the queue terminated to not block cleanup
+        assert(SUCCEEDED(hr));
+        TRACE_ERROR_HR(hr, "Failed to terminate queue");
+
+        TaskQueueTerminated(context);
+    }
+}
+
+void CALLBACK RunContextState::TaskQueueTerminated(void* c) noexcept
+{
+    assert(c);
+    UniquePtr<XTaskQueueCallbackContext> callbackContext{ static_cast<XTaskQueueCallbackContext*>(c) };
+    assert(callbackContext->runContext && !callbackContext->work);
+
+    SharedPtr<RunContextState> runContext{ std::move(callbackContext->runContext) };
+    callbackContext.reset();
+
+    std::unique_lock<std::mutex> lock{ runContext->m_mutex };
+    --runContext->m_pendingTaskQueueCallbacks;
+
+    TRACE_VERBOSE("RunContextState[id=%u] TaskQueueTerminated, %u callbacks remaining", runContext->m_id, runContext->m_pendingTaskQueueCallbacks);
+
+    CheckTerminationAndNotifyListener(std::move(runContext), std::move(lock));
+}
+
+PlayFab::CancellationToken RunContextState::CancellationToken() const noexcept
 {
     return m_cancellationToken;
 }
 
-void RunContext::State::Terminate(_In_ SharedPtr<ITerminationListener> listener, _In_opt_ void* context)
+bool RunContextState::RegisterTerminableAndCheck(ITerminable& terminable) noexcept
 {
     std::unique_lock<std::mutex> lock{ m_mutex };
 
-    // Terminate should be called exactly once during PFCleanup. Allowing multiple termination listeners prevents 
-    // the RunContext from guaranteeing that it has completely cleaning up its state prior to each listener being notified.
-    assert(listener && !m_terminationListener);
-    m_terminationListener = std::move(listener);
-    m_terminationListenerContext = context;
+    if (m_terminated)
+    {
+        return true;
+    }
+
+    m_terminables.push_back(&terminable);
+
+    return false;
+}
+
+bool RunContextState::UnregisterTerminableAndCheck(ITerminable& terminable) noexcept
+{
+    // We take the terminationMutex to ensure that we are properly serialized with respect to the terminating m_terminables.
+    // Because it's a recursive lock, unregistering from within Terminate is safe
+    std::unique_lock<std::recursive_mutex> terminationLock{ m_terminationMutex };
+    std::unique_lock<std::mutex> lock{ m_mutex };
+
+    auto it = std::find(m_terminables.begin(), m_terminables.end(), &terminable);
+    if (it != m_terminables.end())
+    {
+        m_terminables.erase(it);
+    }
+
+    return m_terminated;
+}
+
+using TerminationContext = SharedPtr<RunContextState>;
+
+void RunContextState::Terminate(ITerminationListener& listener, void* listenerContext)
+{
+    std::unique_lock<std::recursive_mutex> terminationLock{ m_terminationMutex };
+    std::unique_lock<std::mutex> lock{ m_mutex };
+
+    assert(!m_terminated);
+    m_terminated = true;
+    m_terminationListener = &listener;
+    m_terminationListenerContext = listenerContext;
 
     // We only needed to keep m_parent alive so we'd be recursively terminated. Safe to release it now that we've been
     // terminated.
     m_parent.reset();
 
-    // Terminate our queue and each of our child terminables
-    Vector<SharedPtr<ITerminable>> terminables;
-    for (auto& weakTerminable : m_terminables)
+    Vector<SharedPtr<RunContextState>> children;
+    for (auto& weakChild : m_children)
     {
-        if (auto sharedTerminable = weakTerminable.lock())
+        if (auto child = weakChild.lock())
         {
-            terminables.emplace_back(sharedTerminable);
+            children.emplace_back(child);
         }
     }
 
-    assert(!m_pendingTerminations);
-    m_pendingTerminations = 1 + terminables.size();
+    m_pendingTerminations = m_terminables.size() + children.size();
+    TRACE_VERBOSE("RunContextState[id=%u] terminating with %u terminables", m_id, m_pendingTerminations);
 
-    TRACE_VERBOSE("RunContext[id=%u] terminating with %u child terminables", m_id, m_pendingTerminations);
+    // context will ensure our lifetime until Termination completes
+    TerminationContext* context = nullptr;
+    if (m_pendingTerminations)
+    {
+        context = MakeUnique<TerminationContext>(shared_from_this()).release(); // reclaimed in OnTerminated
+    }
 
+    // Release state lock but intentionally hold terminationLock while notifying terminables to avoid races with unregister
     lock.unlock();
 
-    m_queue.Terminate(shared_from_this(), nullptr);
-    for (auto& terminable : terminables)
+    // Terminate Queue, registered terminables, and children
+    TaskQueueTerminate();
+
+    for (auto& terminable : m_terminables)
     {
-        terminable->Terminate(shared_from_this(), nullptr);
+        terminable->Terminate(*this, context);
     }
+
+    for (auto& child : children)
+    {
+        child->Terminate(*this, context);
+    }
+
+    lock.lock();
+
+    // Check if termination is trivially complete - TaskQueue was already terminated, we had no terminables, and no children.
+    CheckTerminationAndNotifyListener(shared_from_this(), std::move(lock));
 }
 
-void RunContext::State::OnTerminated(SharedPtr<ITerminationListener> self, void* /*context*/)
+void RunContextState::OnTerminated(void* c) noexcept
 {
     std::unique_lock<std::mutex> lock{ m_mutex };
 
     assert(m_pendingTerminations);
-    TRACE_VERBOSE("RunContext[id=%u] terminable terminated, %u remaining", m_id, --m_pendingTerminations);
+    --m_pendingTerminations;
+    TRACE_VERBOSE("RunContextState[id=%u] terminable terminated, %u remaining", m_id, m_pendingTerminations);
 
     if (!m_pendingTerminations)
     {
-        // Move terminationListener and terminationListenerContext to the stack before releasing self
-        SharedPtr<ITerminationListener> terminationListener{ std::move(m_terminationListener) };
-        void* terminationListenerContext{ m_terminationListenerContext };
+        // Free context and check if termination is complete
+        UniquePtr<TerminationContext> terminationContext{ static_cast<TerminationContext*>(c) };
+        SharedPtr<RunContextState> self = std::move(*terminationContext);
+        terminationContext.reset();
 
-        lock.unlock();
-
-        // Release the reference that was held during termination
-        self.reset();
-
-        ITerminationListener& ref{ *terminationListener }; // we are about to move terminationListener
-        ref.OnTerminated(std::move(terminationListener), terminationListenerContext);
+        CheckTerminationAndNotifyListener(std::move(self), std::move(lock));
     }
 }
 
-RunContext::RunContext(SharedPtr<State> state) noexcept :
+void RunContextState::CheckTerminationAndNotifyListener(SharedPtr<RunContextState> runContext, std::unique_lock<std::mutex> lock) noexcept
+{
+    // Notify listener iff
+    // 1) m_terminationListener is non-null (Terminate has been called and hasn't previously been completed)
+    // 2) there are no pending TaskQueue callbacks
+    // 3) there are no pendinding terminations of registered or child terminables
+
+    assert(lock.owns_lock());
+
+    if (runContext->m_terminationListener && !runContext->m_pendingTaskQueueCallbacks && !runContext->m_pendingTerminations)
+    {
+        // Move listener and listenerContext to the stack before releasing runContext, it may be destroyed here
+        ITerminationListener& listener = *runContext->m_terminationListener;
+        void* listenerContext = runContext->m_terminationListenerContext;
+
+        // reset m_terminationListener to avoid double notifying in some race scenarios
+        runContext->m_terminationListener = nullptr; 
+
+        lock.unlock();
+        runContext.reset();
+
+        listener.OnTerminated(listenerContext);
+    }
+    else
+    {
+        // Explicitly unlock before exiting function scope to ensure runContext isn't destroyed while the mutex is held.
+        // Needed because C++ doesn't define destruction order of function parameters so it may vary depending on compiler
+        lock.unlock();
+    }
+}
+
+//------------------------------------------------------------------------------
+// RunContext
+//------------------------------------------------------------------------------
+
+RunContext::RunContext(SharedPtr<RunContextState> state) noexcept :
     m_state{ std::move(state) }
 {
 }
 
-RunContext RunContext::Root(XTaskQueueHandle backgroundQueue) noexcept
+RunContext RunContext::Root(XTaskQueueHandle queue) noexcept
 {
-    return RunContext{ State::Root(backgroundQueue) };
+    return RunContext{ RunContextState::Root(queue) };
 }
 
 RunContext RunContext::Derive() noexcept
@@ -396,9 +479,24 @@ RunContext RunContext::DeriveOnQueue(XTaskQueueHandle queueHandle) noexcept
     return RunContext{ m_state->DeriveOnQueue(queueHandle) };
 }
 
-TaskQueue RunContext::TaskQueue() const noexcept
+XTaskQueueHandle RunContext::TaskQueueHandle() const noexcept
 {
-    return m_state->TaskQueue();
+    return m_state->TaskQueueHandle();
+}
+
+void RunContext::TaskQueueSubmitWork(SharedPtr<ITaskQueueWork> work, uint32_t delayInMs) const noexcept
+{
+    m_state->TaskQueueSubmitCallback(XTaskQueuePort::Work, std::move(work), delayInMs);
+}
+
+void RunContext::TaskQueueSubmitCompletion(SharedPtr<ITaskQueueWork> completion) const noexcept
+{
+    m_state->TaskQueueSubmitCallback(XTaskQueuePort::Completion, std::move(completion), 0);
+}
+
+void RunContext::TaskQueueTerminate() noexcept
+{
+    m_state->TaskQueueTerminate();
 }
 
 CancellationToken RunContext::CancellationToken() const noexcept
@@ -406,9 +504,19 @@ CancellationToken RunContext::CancellationToken() const noexcept
     return m_state->CancellationToken();
 }
 
-void RunContext::Terminate(SharedPtr<ITerminationListener> listener, void* context) noexcept
+bool RunContext::RegisterTerminableAndCheck(ITerminable& terminable) noexcept
 {
-    m_state->Terminate(std::move(listener), context);
+    return m_state->RegisterTerminableAndCheck(terminable);
+}
+
+bool RunContext::UnregisterTerminableAndCheck(ITerminable& terminable) noexcept
+{
+    return m_state->UnregisterTerminableAndCheck(terminable);
+}
+
+void RunContext::Terminate(ITerminationListener& listener, void* context) noexcept
+{
+    m_state->Terminate(listener, context);
 }
 
 } // namespace PlayFab

--- a/sdk/source/PlayFabSharedInternal/source/RunContext.cpp
+++ b/sdk/source/PlayFabSharedInternal/source/RunContext.cpp
@@ -429,7 +429,7 @@ void RunContextState::CheckTerminationAndNotifyListener(SharedPtr<RunContextStat
     // Notify listener iff
     // 1) m_terminationListener is non-null (Terminate has been called and hasn't previously been completed)
     // 2) there are no pending TaskQueue callbacks
-    // 3) there are no pendinding terminations of registered or child terminables
+    // 3) there are no pendind terminations of registered or child terminables
 
     assert(lock.owns_lock());
 

--- a/sdk/source/PlayFabSharedInternal/source/XAsyncOperation.cpp
+++ b/sdk/source/PlayFabSharedInternal/source/XAsyncOperation.cpp
@@ -20,7 +20,7 @@ RunContext IOperation::RunContext() const noexcept
 
 XAsyncOperationBase::XAsyncOperationBase(PlayFab::RunContext&& runContext) noexcept :
     IOperation{ std::move(runContext) },
-    m_asyncBlock{ RunContext().TaskQueue().Handle(), this, XAsyncCompletionCallback, 0 }
+    m_asyncBlock{ RunContext().TaskQueueHandle(), this, XAsyncCompletionCallback, 0 }
 {
 }
 

--- a/sdk/source/Test/UnitTests/Support/TaskQueue.cpp
+++ b/sdk/source/Test/UnitTests/Support/TaskQueue.cpp
@@ -1,0 +1,54 @@
+#include "stdafx.h"
+#include "TaskQueue.h"
+#include <playfab/core/cpp/PlayFabException.h>
+
+namespace PlayFab
+{
+namespace Wrappers
+{
+
+TaskQueue::TaskQueue(XTaskQueueHandle handle) : m_handle{ handle }
+{
+}
+
+TaskQueue::TaskQueue(XTaskQueueDispatchMode workDispatchMode, XTaskQueueDispatchMode completionDispatchMode)
+{
+    THROW_IF_FAILED(XTaskQueueCreate(workDispatchMode, completionDispatchMode, &m_handle));
+}
+
+TaskQueue::TaskQueue(const TaskQueue& other)
+{
+    THROW_IF_FAILED(XTaskQueueDuplicateHandle(other.m_handle, &m_handle));
+}
+
+TaskQueue::TaskQueue(TaskQueue&& other) noexcept
+{
+    std::swap(m_handle, other.m_handle);
+}
+
+TaskQueue::~TaskQueue() noexcept
+{
+    if (m_handle)
+    {
+        XTaskQueueCloseHandle(m_handle);
+    }
+}
+
+TaskQueue TaskQueue::DeriveWorkQueue() const
+{
+    XTaskQueuePortHandle workPort{ nullptr };
+    THROW_IF_FAILED(XTaskQueueGetPort(m_handle, XTaskQueuePort::Work, &workPort));
+
+    XTaskQueueHandle derivedHandle{ nullptr };
+    THROW_IF_FAILED(XTaskQueueCreateComposite(workPort, workPort, &derivedHandle));
+
+    return TaskQueue{ derivedHandle };
+}
+
+XTaskQueueHandle TaskQueue::Handle() const noexcept
+{
+    return m_handle;
+}
+
+}
+}

--- a/sdk/source/Test/UnitTests/Support/TaskQueue.h
+++ b/sdk/source/Test/UnitTests/Support/TaskQueue.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <XTaskQueue.h>
+
+namespace PlayFab
+{
+namespace Wrappers
+{
+
+class TaskQueue
+{
+public:
+    TaskQueue(XTaskQueueHandle handle); // Takes ownership of handle
+    TaskQueue(XTaskQueueDispatchMode workDispatchMode, XTaskQueueDispatchMode completionDispatchMode);
+    TaskQueue(const TaskQueue& other);
+    TaskQueue(TaskQueue&& other) noexcept;
+    TaskQueue& operator=(TaskQueue const& other) noexcept = delete;
+    TaskQueue& operator=(TaskQueue&& other) noexcept = delete;
+    ~TaskQueue() noexcept;
+
+    TaskQueue DeriveWorkQueue() const;
+    XTaskQueueHandle Handle() const noexcept;
+
+private:
+    XTaskQueueHandle m_handle{ nullptr };
+};
+
+}
+}

--- a/sdk/source/Test/UnitTests/Support/TestSession.h
+++ b/sdk/source/Test/UnitTests/Support/TestSession.h
@@ -9,7 +9,6 @@ namespace PlayFab
 namespace Wrappers
 {
 
-// RAII wrapper around PlayFabCore initialization
 class TestSession
 {
 public:

--- a/sdk/source/Test/UnitTests/Tests/AsyncOpTests.cpp
+++ b/sdk/source/Test/UnitTests/Tests/AsyncOpTests.cpp
@@ -55,7 +55,7 @@ public:
         tc.AwaitResult();
     }
 
-    TEST_METHOD(ChanedOperation)
+    TEST_METHOD(ChainedOperation)
     {
         AsyncTestContext tc;
 

--- a/sdk/source/Test/UnitTests/Tests/GlobalStateTests.cpp
+++ b/sdk/source/Test/UnitTests/Tests/GlobalStateTests.cpp
@@ -24,7 +24,7 @@ public:
     {
         PFMemoryHooks hooks{ nullptr, nullptr };
         VERIFY_SUCCEEDED(PFMemSetFunctions(&hooks));
-        Assert::IsTrue(s_allocCalls == s_freeCalls);
+        Assert::AreEqual(s_allocCalls.load(), s_freeCalls.load());
     }
 
 private:


### PR DESCRIPTION
This change fixes a couple of RunContext Termination bugs, clarifies the RunContext interface, and adds more complete doc comments describing its purpose and usage.

The high-level goal of RunContext::Terminate is to provide a way to ensure all async work associated with the RunContext has completed and been completely cleaned up.  This allows PFUninitializeAsync to guarantee that no SDK asynchronous operations or dynamic memory allocations are remaining when we return to the title, allowing them to safely cleanup their memory manager, Http providers, task queue dispatchers, etc.  

The old RunContext::Terminate flow was roughly this:
1. Terminate XTaskQueue
2. Terminate any derived (child) RunContexts
3. Wait for all XTaskQueueTerminated & child OnTerminated callbacks
4. Notify ITerminationListener

This flow has a two main issues:
1. The guarantees that XTaskQueueTerminate makes are weaker than what we want to guarantee for RunContext::Terminate.  Specifically, an XTaskQueueTermination callback is invoked after all other XTaskQueue callbacks have been invoked, but it doesn't guarantee that they have completed.  This means that if an XTaskQueue callback needs significant time to run and finish cleaning up, it may not finish beyond step 4 of the termination flow above.
2. XAsyncProvider state is independent of and not tracked by its associated RunContext.  This means that even if we guarantee that the XAsync API has completed, we need additional logic to ensure the XAsyncProvider has been cleaned up (this can't happen until the client has retrieved the result)

To solve issue 1), I've removed the XTaskQueue wrappers (TaskQueue::SubmitWork, TaskQueue::Terminate, etc.) and replaced them with RunContext shims (RunContext::TaskQueueSubmitWork, RunContext::TaskQueueTerminate, etc.).  These shims maintain a counter of pending TaskQueue callbacks before calling the XTaskQueue APIs.  When RunContext::Terminate is called, it will wait until all callbacks have finished before notifying the ITerminationListener. 

Issue 2) is solved by adding the RunContext::RegisterTerminableAndCheck API.  This allows arbitrary async work to be attached and tracked by the RunContext, ensuring it completes before RunContext::Terminate notifies the ITerminationListener.

The new RunContext::Terminate flow is adds 2 additional steps compared to before:
1. Terminate XTaskQueue
2. Terminate any derived (child) RunContexts
3. **Terminate any additional registered Terminables**
4. Wait for all XTaskQueueTerminated & child OnTerminated callbacks
5. **Wait for all XTaskQueue callbacks to complete**
6. Notify ITerminationListener
